### PR TITLE
fix(mfa): desbloquear el acceso al panel admin tras enrolar el segund…

### DIFF
--- a/.compliance/docs/21719-mfa-operacion.md
+++ b/.compliance/docs/21719-mfa-operacion.md
@@ -7,7 +7,10 @@ Alcance: roles `admin` y `judge`.
 Los siguientes eventos se registran en `AuditLog` sin secretos ni codigos de un solo uso:
 - inicio de enrolamiento MFA;
 - activacion de MFA;
-- desafio MFA aprobado, identificando solo si se uso TOTP o codigo de recuperacion.
+- desafio MFA aprobado, identificando solo si se uso TOTP o codigo de recuperacion;
+- intento fallido de activacion o de desafio, indicando si fue por codigo incorrecto
+  (`invalid_code`) o por bloqueo del limite de intentos (`rate_limited`);
+- deshabilitacion de MFA por el procedimiento de recuperacion, con el motivo registrado.
 
 Estos eventos se habilitan junto con la migracion final de privacidad.
 
@@ -19,8 +22,14 @@ Exigir un segundo factor TOTP para acceder a rutas administrativas y de jueces, 
 - Modelo `MfaRecoveryCode`: codigos de recuperacion hasheados y de un solo uso.
 - Cifrado AES-256-GCM para secreto TOTP en [lib/mfa.ts](lib/mfa.ts).
 - Cookie HTTP-only firmada para acreditar segundo factor durante 8 horas.
-- Rate limit de cinco intentos cada cinco minutos por usuario/IP en el desafio MFA.
+- Rate limit de cinco intentos cada cinco minutos por usuario/IP en [lib/mfa-attempts.ts](lib/mfa-attempts.ts),
+  compartido entre la activacion y el desafio para que ambos no sumen presupuestos separados.
 - Middleware de proteccion para `/admin`, `/api/admin`, `/judge` y `/api/judge`.
+
+La cookie firmada es la prueba del segundo factor: el middleware no puede consultar la
+base de datos en el runtime edge, y el claim `mfaEnabled` del JWT queda desactualizado
+cuando alguien se enrola con la sesion ya iniciada. Las paginas `/auth/mfa/*` si
+consultan el estado real de enrolamiento antes de mostrarse.
 
 ## Variables de entorno obligatorias
 - `MFA_ENCRYPTION_KEY`: 32 bytes codificados en base64. Generar con:
@@ -38,17 +47,32 @@ Nunca rotar `MFA_ENCRYPTION_KEY` sin un plan de recifrado: los secretos TOTP exi
 2. El middleware redirige a `/auth/mfa/setup` si MFA aun no esta habilitado.
 3. La persona genera un QR, lo escanea en su aplicacion autenticadora y almacena los diez codigos de recuperacion.
 4. Al ingresar un TOTP valido, el sistema activa MFA.
-5. La confirmacion emite de inmediato una cookie MFA firmada, por lo que la persona puede volver a la ruta protegida sin quedar en un bucle de redireccion.
+5. La confirmacion emite de inmediato la cookie MFA firmada y lleva a la ruta protegida
+   sin pedir un segundo codigo, porque el factor ya quedo acreditado en ese mismo paso.
 6. La cookie MFA expira en ocho horas; despues debe completar `/auth/mfa/challenge` nuevamente.
 
 ## Recuperacion
 - Cada codigo de recuperacion se guarda como hash bcrypt y se invalida al usarse.
-- Si se pierden aplicacion y codigos, un administrador autorizado debe deshabilitar MFA mediante un procedimiento interno documentado, verificar identidad del titular y dejar evidencia de la accion.
+- Si se pierden aplicacion y codigos, un administrador autorizado verifica la identidad
+  del titular y deshabilita MFA con:
+
+```powershell
+npm run mfa:reset -- persona@ejemplo.cl "motivo y forma de verificacion de identidad"
+```
+
+  El script borra el secreto TOTP y los codigos de recuperacion, y registra
+  `MFA_DISABLED` en `AuditLog` con el motivo indicado. La persona vuelve a enrolarse en
+  su siguiente acceso a una ruta privilegiada.
+- Riesgo residual: la cookie MFA vigente de esa cuenta sigue siendo valida hasta que
+  expire. Si el motivo del reset es sospecha de compromiso, desactiva ademas la cuenta
+  (`isActive = false`) en vez de solo reiniciar el segundo factor.
 
 ## Evidencia para auditoria
 - Migracion Prisma: `prisma/migrations/20260822021324_add_privileged_mfa/migration.sql`.
 - APIs: `app/api/auth/mfa/setup`, `confirm` y `challenge`.
-- Proteccion de rutas: `middleware.ts`.
+- Limite de intentos y registro de fallos: `lib/mfa-attempts.ts`.
+- Proteccion de rutas: `middleware.ts` y el guard de `lib/permissions.ts`.
+- Recuperacion: `prisma/scripts/mfa-reset.cts`.
 - Dependencias: `otplib`, `qrcode`, `rate-limiter-flexible` y `@types/qrcode`.
 
 ## Prueba operativa minima
@@ -56,9 +80,11 @@ Nunca rotar `MFA_ENCRYPTION_KEY` sin un plan de recifrado: los secretos TOTP exi
 2. Iniciar sesion con cuenta admin o judge.
 3. Abrir `/admin` o `/judge/dashboard`: debe redirigir a setup.
 4. Enrolar TOTP, confirmar codigo y guardar recovery codes.
-5. Volver a ruta protegida: debe solicitar challenge.
-6. Ingresar un TOTP valido: debe permitir acceso.
-7. Repetir con un recovery code y verificar que no pueda reutilizarse.
+5. Al confirmar debe entrar directamente a la ruta protegida, sin pedir otro codigo.
+6. Cerrar la sesion MFA y volver a la ruta protegida: debe solicitar challenge.
+7. Ingresar un TOTP valido: debe permitir acceso.
+8. Repetir con un recovery code y verificar que no pueda reutilizarse.
+9. Fallar el codigo hasta agotar el limite: debe responder 429 y quedar en `AuditLog`.
 
 ---
 DISCLAIMER: Este documento no constituye asesoria legal. Es un runbook tecnico de seguridad para apoyar el cumplimiento de la Ley 21.719.

--- a/.compliance/state.json
+++ b/.compliance/state.json
@@ -98,8 +98,8 @@
     },
     "sec-mfa": {
       "status": "partial",
-      "evidence": "prisma/migrations/20260822021324_add_privileged_mfa/migration.sql, app/api/auth/mfa, middleware.ts, .compliance/docs/21719-mfa-operacion.md",
-      "remediation": "Configurar MFA_ENCRYPTION_KEY y MFA_SESSION_SECRET en cada entorno, enrolar cuentas admin/judge y ejecutar la prueba operativa documentada."
+      "evidence": "prisma/migrations/20260822021324_add_privileged_mfa/migration.sql, app/api/auth/mfa, lib/mfa-attempts.ts, lib/permissions.ts, middleware.ts, prisma/scripts/mfa-reset.cts, .compliance/docs/21719-mfa-operacion.md",
+      "remediation": "Prueba operativa ejecutada en desarrollo con enrolamiento, desafio, codigo de recuperacion y bloqueo por limite de intentos. Pendiente: configurar MFA_ENCRYPTION_KEY y MFA_SESSION_SECRET en produccion y enrolar las cuentas admin/judge reales."
     },
     "sec-logs": {
       "status": "partial",

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ npx prisma studio
 | `npm run lint` | Análisis estático con ESLint. |
 | `npx prisma migrate dev --name <nombre>` | Crea y aplica una migración. |
 | `npx prisma db seed` | Puebla catálogos, categorías y rúbricas. |
+| `npm run mfa:reset -- <email> "<motivo>"` | Deshabilita el MFA de una cuenta privilegiada que perdió su autenticador y sus códigos de recuperación. Deja registro en `AuditLog`. |
 | `npx prisma studio` | Explorador visual de la base de datos. |
 | `npx tsc --noEmit` | **Verificación de tipos.** Ver la nota siguiente. |
 

--- a/app/api/auth/mfa/challenge/route.ts
+++ b/app/api/auth/mfa/challenge/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import bcrypt from "bcrypt";
-import { RateLimiterMemory } from "rate-limiter-flexible";
 import { verify } from "otplib";
 import { z } from "zod";
 
 import { authOptions } from "@/lib/auth";
+import { consumeMfaAttempt, getMfaAttemptKey, recordMfaFailure } from "@/lib/mfa-attempts";
 import { createMfaSessionValue, decryptMfaSecret, mfaCookie } from "@/lib/mfa";
 import { prisma } from "@/lib/prisma";
 import { getRequestMetadata } from "@/lib/privacy";
@@ -14,17 +14,6 @@ const challengeSchema = z.object({
   code: z.string().trim().min(6).max(32),
 });
 
-const limiter = new RateLimiterMemory({
-  points: 5,
-  duration: 5 * 60,
-});
-
-function getClientIp(req: NextRequest): string {
-  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-    || req.headers.get("x-real-ip")
-    || "unknown";
-}
-
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
 
@@ -32,24 +21,23 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "No autorizado" }, { status: 401 });
   }
 
+  const userId = session.user.id;
   const parsed = challengeSchema.safeParse(await req.json());
   if (!parsed.success) {
     return NextResponse.json({ error: "Codigo MFA invalido" }, { status: 400 });
   }
 
-  const rateLimitKey = `${session.user.id}:${getClientIp(req)}`;
   try {
-    await limiter.consume(rateLimitKey);
-  } catch {
-    return NextResponse.json(
-      { error: "Demasiados intentos. Intenta nuevamente en unos minutos." },
-      { status: 429 },
-    );
-  }
+    if (!(await consumeMfaAttempt(getMfaAttemptKey(userId, req)))) {
+      await recordMfaFailure({ userId, action: "MFA_CHALLENGE_FAILED", reason: "rate_limited", request: req });
+      return NextResponse.json(
+        { error: "Demasiados intentos. Intenta nuevamente en unos minutos." },
+        { status: 429 },
+      );
+    }
 
-  try {
     const user = await prisma.user.findUnique({
-      where: { id: session.user.id },
+      where: { id: userId },
       select: {
         id: true,
         totpEnabled: true,
@@ -86,6 +74,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (!valid) {
+      await recordMfaFailure({ userId, action: "MFA_CHALLENGE_FAILED", reason: "invalid_code", request: req });
       return NextResponse.json({ error: "Codigo MFA incorrecto" }, { status: 400 });
     }
 

--- a/app/api/auth/mfa/confirm/route.ts
+++ b/app/api/auth/mfa/confirm/route.ts
@@ -4,6 +4,7 @@ import { verify } from "otplib";
 import { z } from "zod";
 
 import { authOptions } from "@/lib/auth";
+import { consumeMfaAttempt, getMfaAttemptKey, recordMfaFailure } from "@/lib/mfa-attempts";
 import { createMfaSessionValue, decryptMfaSecret, mfaCookie } from "@/lib/mfa";
 import { prisma } from "@/lib/prisma";
 import { getRequestMetadata } from "@/lib/privacy";
@@ -24,14 +25,23 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "MFA no requerido para este usuario" }, { status: 403 });
   }
 
+  const userId = session.user.id;
   const parsed = confirmationSchema.safeParse(await req.json());
   if (!parsed.success) {
     return NextResponse.json({ error: "Codigo MFA invalido" }, { status: 400 });
   }
 
   try {
+    if (!(await consumeMfaAttempt(getMfaAttemptKey(userId, req)))) {
+      await recordMfaFailure({ userId, action: "MFA_ENABLE_FAILED", reason: "rate_limited", request: req });
+      return NextResponse.json(
+        { error: "Demasiados intentos. Intenta nuevamente en unos minutos." },
+        { status: 429 },
+      );
+    }
+
     const user = await prisma.user.findUnique({
-      where: { id: session.user.id },
+      where: { id: userId },
       select: { id: true, totpSecretEncrypted: true, totpEnabled: true },
     });
 
@@ -50,6 +60,7 @@ export async function POST(req: NextRequest) {
     });
 
     if (!result.valid) {
+      await recordMfaFailure({ userId, action: "MFA_ENABLE_FAILED", reason: "invalid_code", request: req });
       return NextResponse.json({ error: "Codigo MFA incorrecto" }, { status: 400 });
     }
 

--- a/app/auth/mfa/challenge/page.tsx
+++ b/app/auth/mfa/challenge/page.tsx
@@ -1,11 +1,17 @@
 import MfaClient from "@/components/login/MfaClient";
+import { ensureMfaPage } from "@/lib/permissions";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export default async function MfaChallengePage({ searchParams }: { searchParams?: SearchParams }) {
   const params = (await searchParams) ?? {};
   const candidate = typeof params.callbackUrl === "string" ? params.callbackUrl : "/";
   const callbackUrl = candidate.startsWith("/") && !candidate.startsWith("//") ? candidate : "/";
+
+  await ensureMfaPage("challenge", callbackUrl);
 
   return <MfaClient mode="challenge" callbackUrl={callbackUrl} />;
 }

--- a/app/auth/mfa/setup/page.tsx
+++ b/app/auth/mfa/setup/page.tsx
@@ -1,11 +1,17 @@
 import MfaClient from "@/components/login/MfaClient";
+import { ensureMfaPage } from "@/lib/permissions";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export default async function MfaSetupPage({ searchParams }: { searchParams?: SearchParams }) {
   const params = (await searchParams) ?? {};
   const candidate = typeof params.callbackUrl === "string" ? params.callbackUrl : "/";
   const callbackUrl = candidate.startsWith("/") && !candidate.startsWith("//") ? candidate : "/";
+
+  await ensureMfaPage("setup", callbackUrl);
 
   return <MfaClient mode="setup" callbackUrl={callbackUrl} />;
 }

--- a/components/login/MfaClient.tsx
+++ b/components/login/MfaClient.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import toast from "react-hot-toast";
 
 type MfaClientProps = {
@@ -17,6 +18,7 @@ type SetupData = {
 
 export default function MfaClient({ mode, callbackUrl }: MfaClientProps) {
   const router = useRouter();
+  const { update: refreshSession } = useSession();
   const [setupData, setSetupData] = useState<SetupData | null>(null);
   const [code, setCode] = useState("");
   const [pending, setPending] = useState(false);
@@ -48,12 +50,12 @@ export default function MfaClient({ mode, callbackUrl }: MfaClientProps) {
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || "Codigo MFA invalido");
 
-      if (mode === "setup") {
-        toast.success("MFA activado. Ahora verifica tu segundo factor para continuar.");
-        router.replace(`/auth/mfa/challenge?callbackUrl=${encodeURIComponent(callbackUrl)}`);
-        return;
-      }
+      // Ambos endpoints emiten la cookie del segundo factor, pero el JWT todavia
+      // dice mfaEnabled: false si el enrolamiento ocurrio con la sesion ya iniciada.
+      // Refrescarlo antes de navegar evita volver a caer en el guard de MFA.
+      await refreshSession();
 
+      toast.success(mode === "setup" ? "MFA activado correctamente." : "Segundo factor verificado.");
       router.replace(callbackUrl);
       router.refresh();
     } catch (error) {

--- a/lib/mfa-attempts.ts
+++ b/lib/mfa-attempts.ts
@@ -1,0 +1,53 @@
+import { RateLimiterMemory } from "rate-limiter-flexible";
+
+import { prisma } from "@/lib/prisma";
+import { getRequestMetadata } from "@/lib/privacy";
+
+const MAX_ATTEMPTS = 5;
+const WINDOW_SECONDS = 5 * 60;
+
+// Presupuesto compartido entre la confirmacion de enrolamiento y el desafio: ambos
+// validan un TOTP de seis digitos, asi que un limite por endpoint duplicaria los
+// intentos disponibles para adivinarlo.
+const limiter = new RateLimiterMemory({
+  points: MAX_ATTEMPTS,
+  duration: WINDOW_SECONDS,
+});
+
+export function getMfaAttemptKey(userId: string, request: Request): string {
+  return `${userId}:${getRequestMetadata(request).ip ?? "unknown"}`;
+}
+
+export async function consumeMfaAttempt(key: string): Promise<boolean> {
+  try {
+    await limiter.consume(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type MfaFailure = {
+  userId: string;
+  action: "MFA_ENABLE_FAILED" | "MFA_CHALLENGE_FAILED";
+  reason: "invalid_code" | "rate_limited";
+  request: Request;
+};
+
+/**
+ * Registra el intento fallido de segundo factor. La Ley 21.719 exige poder auditar
+ * los accesos privilegiados, y sin los fallos no se detecta un ataque de fuerza bruta.
+ */
+export async function recordMfaFailure({ userId, action, reason, request }: MfaFailure): Promise<void> {
+  await prisma.auditLog.create({
+    data: {
+      actorUserId: userId,
+      action,
+      resourceType: "User",
+      resourceId: userId,
+      outcome: "FAILURE",
+      metadata: { reason },
+      ...getRequestMetadata(request),
+    },
+  });
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,7 +1,44 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "./auth";
+import { prisma } from "./prisma";
 import { redirect } from "next/navigation";
 import { NextResponse } from "next/server";
+
+const PRIVILEGED_ROLES = ["admin", "judge"];
+
+/**
+ * Guard de las paginas MFA. Consulta el estado de enrolamiento en la base de datos
+ * en vez de confiar en el claim mfaEnabled del JWT, que queda desactualizado cuando
+ * alguien se enrola con una sesion ya iniciada.
+ */
+export async function ensureMfaPage(mode: "setup" | "challenge", callbackUrl: string) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect(`/auth/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  }
+
+  const roles = Array.isArray(session.user.roles) ? session.user.roles : [];
+  if (!roles.some((role) => PRIVILEGED_ROLES.includes(role))) {
+    redirect("/");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { totpEnabled: true },
+  });
+  const mfaEnabled = user?.totpEnabled === true;
+
+  if (mode === "setup" && mfaEnabled) {
+    redirect(`/auth/mfa/challenge?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  }
+
+  if (mode === "challenge" && !mfaEnabled) {
+    redirect(`/auth/mfa/setup?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  }
+
+  return session;
+}
 
 export async function ensureAdminPage() {
   const session = await getServerSession(authOptions);

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,11 +12,9 @@ export async function middleware(req: NextRequest) {
   const isPrivilegedScope = PRIVILEGED_PATHS.some((re) => re.test(pathname));
   if (!isPrivilegedScope) return NextResponse.next();
 
-  // Usamos el secret para desencriptar el JWT
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
   const isApi = pathname.startsWith("/api/");
 
-  // Si no hay token (no logueado), redirigir
   if (!token) {
     if (isApi) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     const loginUrl = new URL("/auth/login", req.url);
@@ -24,29 +22,28 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  // --- INICIO DE LA CORRECCIÓN ---
-
-  // 1. Obtenemos el array 'roles' del token (que definimos en lib/auth.ts)
-  const roles = (token as any).roles;
-
-  // 2. Comprobamos si 'roles' es un array Y si incluye "admin"
-  const hasAdminRole = Array.isArray(roles) && roles.includes("admin");
-  const hasJudgeRole = Array.isArray(roles) && roles.includes("judge");
+  const roles = Array.isArray(token.roles) ? token.roles : [];
+  const hasAdminRole = roles.includes("admin");
+  const hasJudgeRole = roles.includes("judge");
   const hasRequiredRole = isAdminScope ? hasAdminRole : (hasAdminRole || hasJudgeRole);
 
   if (!hasRequiredRole) {
-    // Si no es admin, lo redirigimos
     if (isApi) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     return NextResponse.redirect(new URL("/", req.url));
   }
 
   const userId = token.sub;
-  const mfaEnabled = (token as any).mfaEnabled === true;
+  const mfaEnabled = token.mfaEnabled === true;
+
+  // La cookie va firmada por el servidor y ligada al userId, y solo se emite tras
+  // confirmar o superar el desafio: su validez basta como prueba del segundo factor.
+  // El claim mfaEnabled del JWT puede venir desactualizado (se enrolo despues de
+  // emitir el token), asi que solo decide a donde enviar a quien aun no verifico.
   const mfaVerified = userId
     ? await hasValidMfaSession(req.cookies.get(mfaCookieName)?.value, userId)
     : false;
 
-  if (!mfaEnabled || !mfaVerified) {
+  if (!mfaVerified) {
     if (isApi) {
       return NextResponse.json(
         { error: "MFA_REQUIRED", setupRequired: !mfaEnabled },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",
-    "geo:snapshot": "node scripts/snapshot-cl-geo.mjs"
+    "geo:snapshot": "node scripts/snapshot-cl-geo.mjs",
+    "mfa:reset": "ts-node prisma/scripts/mfa-reset.cts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/prisma/scripts/mfa-reset.cts
+++ b/prisma/scripts/mfa-reset.cts
@@ -1,0 +1,83 @@
+// prisma/scripts/mfa-reset.cts
+// Usamos sintaxis CommonJS (require) debido al formato .cts
+require("dotenv/config");
+const { PrismaClient } = require("@prisma/client");
+const { PrismaPg } = require("@prisma/adapter-pg");
+const { Pool } = require("pg");
+
+/**
+ * Procedimiento de recuperacion de MFA privilegiado (Ley 21.719).
+ *
+ * Deshabilita el segundo factor de una cuenta que perdio su aplicacion autenticadora
+ * y sus codigos de recuperacion, dejando evidencia en AuditLog. Tras ejecutarlo, la
+ * persona vuelve a enrolarse en su siguiente acceso a una ruta privilegiada.
+ *
+ * Uso: npm run mfa:reset -- persona@ejemplo.cl "verificacion telefonica 2026-08-22"
+ *
+ * La sesion MFA vigente de esa cuenta sigue siendo valida hasta que expire (8 horas).
+ * Si el motivo del reset es una sospecha de compromiso, desactiva ademas la cuenta.
+ */
+async function main() {
+  // Unimos el resto de los argumentos para que el motivo no se trunque a una sola
+  // palabra si el shell no respeta las comillas: es la evidencia de la auditoria.
+  const [email, ...reasonParts] = process.argv.slice(2);
+  const reason = reasonParts.join(" ").trim();
+
+  if (!email || !reason) {
+    throw new Error(
+      'Uso: npm run mfa:reset -- <email> "<motivo y verificacion de identidad>"',
+    );
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, totpEnabled: true },
+    });
+
+    if (!user) {
+      throw new Error(`No existe una cuenta con el correo ${email}`);
+    }
+
+    const { recoveryCodesRemoved } = await prisma.$transaction(async (transaction: any) => {
+      const removed = await transaction.mfaRecoveryCode.deleteMany({
+        where: { userId: user.id },
+      });
+      await transaction.user.update({
+        where: { id: user.id },
+        data: {
+          totpSecretEncrypted: null,
+          totpEnabled: false,
+          totpConfirmedAt: null,
+        },
+      });
+      await transaction.auditLog.create({
+        data: {
+          actorUserId: user.id,
+          action: "MFA_DISABLED",
+          resourceType: "User",
+          resourceId: user.id,
+          outcome: "SUCCESS",
+          metadata: { reason, performedVia: "cli" },
+        },
+      });
+
+      return { recoveryCodesRemoved: removed.count };
+    });
+
+    console.log(`MFA deshabilitado para ${user.email}`);
+    console.log(`Codigos de recuperacion eliminados: ${recoveryCodesRemoved}`);
+    console.log("La persona debera enrolarse de nuevo al entrar a una ruta privilegiada.");
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
…o factor

Una cuenta admin que completaba el enrolamiento MFA quedaba encerrada fuera del panel: el middleware exigia el claim mfaEnabled del JWT, que sigue en false cuando el enrolamiento ocurre con la sesion ya iniciada, y la devolvia a /auth/mfa/setup, donde la API responde 409 porque el MFA ya estaba activo.

Ahora la cookie firmada del segundo factor basta como prueba en el middleware, el cliente refresca la sesion antes de navegar y las paginas /auth/mfa/* consultan el estado real de enrolamiento en la base de datos. La confirmacion entra directo a la ruta protegida, como ya describia el runbook de la Ley 21.719.

Cierra ademas dos brechas del control sec-mfa: se auditan los intentos fallidos y el limite de cinco intentos por cinco minutos pasa a compartirse entre la activacion y el desafio. Se agrega el procedimiento de recuperacion (npm run mfa:reset) que la documentacion prometia y no existia.